### PR TITLE
Allow `Bearer` token prefix to be case-insensitive

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -671,7 +671,7 @@ func (plugin *JWTPlugin) extractTokenFromHeader(request *http.Request) string {
 		request.Header.Del(plugin.headerName)
 	}
 
-	if strings.HasPrefix(token, "Bearer ") {
+	if len(token) >= 7 && strings.EqualFold(token[:7], "Bearer ") {
 		return token[7:]
 	}
 	return token


### PR DESCRIPTION
As described in Section 2.3 of RFC5234, the string `Bearer` is case-insensitive.

See also this article: https://auth0.com/blog/the-bearer-token-case/

I considered doing `strings.HasPrefix(Strings.ToLower(token), "bearer ")` since it would be closer to the current code, but that would unnecessarily process the entire header, including the actual token. So I refactored slightly to check the length of the slice first, then case-insensitively-compare just the prefix, using `strings.EqualFold`.

In lieu of actually building and testing this change, I've shown how it is expected to work with a playground snippet: https://go.dev/play/p/-tV3U9uoBBP